### PR TITLE
Remove "_key" from schema fields

### DIFF
--- a/datapackage.json
+++ b/datapackage.json
@@ -10,38 +10,32 @@
           {
             "name": "Color.Name",
             "type": "string",
-            "format": "default",
-            "_key": "Color.Name"
+            "format": "default"
           },
           {
             "name": "Hex.Code",
             "type": "string",
-            "format": "default",
-            "_key": "Hex.Code"
+            "format": "default"
           },
           {
             "name": "Dec.Code",
             "type": "string",
-            "format": "default",
-            "_key": "Dec.Code"
+            "format": "default"
           },
           {
             "name": "X.Code",
             "type": "string",
-            "format": "default",
-            "_key": "X.Code"
+            "format": "default"
           },
           {
             "name": "HSL.Code",
             "type": "string",
-            "format": "default",
-            "_key": "HSL.Code"
+            "format": "default"
           },
           {
             "name": "CMYK.Code",
             "type": "string",
-            "format": "default",
-            "_key": "CMYK.Code"
+            "format": "default"
           }
         ]
       }


### PR DESCRIPTION
They were added by a bug on `datapackage-ui` fixed by https://github.com/frictionlessdata/datapackage-ui/commit/857672b46a4251830b679b2155b7aecf713fe9fd